### PR TITLE
Added the idle ai to the settings selection and made it default

### DIFF
--- a/ui/mods/instant_sandbox/settings.js
+++ b/ui/mods/instant_sandbox/settings.js
@@ -82,8 +82,8 @@
     instant_sandbox_ai_personality: {
       title: 'AI Personality',
       type: 'select',
-      options: ['Normal', 'Hard', 'Relentless', 'Absurd'],
-      default: 'Normal',
+      options: ['Idle','Normal', 'Hard', 'Relentless', 'Absurd'],
+      default: 'Idle',
     },
     instant_sandbox_armies: {
       title: 'Armies',


### PR DESCRIPTION
Most of the time when using sandbox an idle ai is desired, at least as an option.

Idle ai was added to the base game at some point in the past few years so should not cause any issues adding it here.

If it was somehow disabled this mod defaults to normal ai if it was an invalid choice anyway.


Tested with Queller, ai personalitys, and ai framework progressively disabled and worked as expected.